### PR TITLE
Instead of using method_missing, use String.include to include the color methods

### DIFF
--- a/lib/motion-redgreen/string.rb
+++ b/lib/motion-redgreen/string.rb
@@ -1,5 +1,1 @@
-class String
-  def method_missing(sym, *args, &block)
-    Term::ANSIColor.send(sym) { self } rescue super
-  end
-end
+String.send :include, Term::ANSIColor


### PR DESCRIPTION
I have been working on another gem (https://github.com/siuying/motion-stump) that use method_missing, and found that there are conflicts in method_missing.

I tried several workaround, but found that use:

```
String.send :include, Term::ANSIColor
```

is simple and work.
