### PR TITLE
Added :progress output style

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,13 @@ Optionally, specify the output style in your Rakefile:
 ```ruby
 Motion::Project::App.setup do |app|
   # ...
-  app.redgreen_style = :full # default: :focused
+  app.redgreen_style = :full # default: :focused, also can use :progress
 end
 ```
 
-The available styles are *:focused* and *:full*.
+The available styles are `:focused`, `:full`, and `:progress`.
+
+Example of the `:progress` output style:
+
+![progress](https://cloud.githubusercontent.com/assets/1479215/5492859/065cab86-869a-11e4-8a75-c0c35ce332e0.png)
+

--- a/lib/motion-redgreen/spec_setup.rb
+++ b/lib/motion-redgreen/spec_setup.rb
@@ -100,5 +100,47 @@ else
         end
       end
     end
+  elsif style == :progress
+    module Bacon
+      module SpecDoxOutput
+        def handle_specification_begin(name)
+        end
+
+        def handle_specification_end
+        end
+
+        def handle_requirement_begin(description)
+          @spec_description_cache = description
+        end
+
+        def handle_requirement_end(error)
+          @error_summaries ||= []
+          if error.empty?
+            print ".".green
+          else
+            color = color_for(error)
+            spec_error_message = @spec_description_cache + "\n"
+            spec_error_message += "\n#{spaces}[#{error}]".send(color)
+            @error_summaries << spec_error_message
+
+            if error =~ /MISSING/
+              print "?".yellow
+            else
+              print "F".red
+            end
+          end
+        end
+
+        def handle_summary
+          puts ""
+          if @error_summaries && @error_summaries.length > 0
+            puts @error_summaries.join("\n\n")
+            puts "\nBACKTRACE: #{ErrorLog}".red
+          end
+          puts "%d specifications (%d requirements), %d failures, %d errors" %
+          Counter.values_at(:specifications, :requirements, :failed, :errors)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
I wanted a tighter output, so I added `:progress`.

![screen shot 2014-12-18 at 9 39 53 am](https://cloud.githubusercontent.com/assets/1479215/5492875/32c5cf68-869a-11e4-870f-1eaf8a492ea1.png)

![screen shot 2014-12-18 at 9 39 29 am](https://cloud.githubusercontent.com/assets/1479215/5492878/35fb613e-869a-11e4-9787-2154eb4ee257.png)
